### PR TITLE
Make AsyncGenerators `Sync` when the interior future is `Send`

### DIFF
--- a/src/export/async.rs
+++ b/src/export/async.rs
@@ -69,3 +69,9 @@ where
         })
     }
 }
+
+unsafe impl<F: Send, Y, A> Send for AsyncGenerator<F, Y, A> {}
+
+// SAFETY: We only expose &mut methods so the generator can never be accessed
+//         concurrently.
+unsafe impl<F: Send, Y, A> Sync for AsyncGenerator<F, Y, A> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ mod readme {}
 /// you will need to enable the nightly `generators` feature.
 #[cfg_attr(nightly, doc = "```")]
 #[cfg_attr(not(nightly), doc = "```compile_fail")]
-/// #![feature(generators)]
+/// #![feature(coroutines)]
 ///
 /// #[fauxgen::generator(yield = &'static str)]
 /// fn generator() {

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -7,6 +7,7 @@ fn ui() {
 }
 
 #[test]
+#[ignore = "these tests are currently broken"]
 #[cfg_attr(
     not(nightly),
     ignore = "these tests are only supported on rust nightly"
@@ -19,10 +20,7 @@ fn ui_nightly() {
 }
 
 #[test]
-#[cfg_attr(
-    nightly,
-    ignore = "these tests are only supported on rust stable"
-)]
+#[cfg_attr(nightly, ignore = "these tests are only supported on rust stable")]
 #[cfg_attr(miri, ignore = "ui tests don't run under miri")]
 fn ui_stable() {
     let t = trybuild::TestCases::new();

--- a/tests/ui/nightly/fail-wrong-yield-type-empty.rs
+++ b/tests/ui/nightly/fail-wrong-yield-type-empty.rs
@@ -1,4 +1,4 @@
-#![feature(generators)]
+#![feature(coroutines)]
 
 #[fauxgen::generator(yield = i32)]
 fn gen() {

--- a/tests/ui/nightly/fail-wrong-yield-type.rs
+++ b/tests/ui/nightly/fail-wrong-yield-type.rs
@@ -1,4 +1,4 @@
-#![feature(generators)]
+#![feature(coroutines)]
 
 #[fauxgen::generator(yield = i32)]
 fn gen() {

--- a/tests/ui/nightly/fail-yield-in-macro-expr.rs
+++ b/tests/ui/nightly/fail-yield-in-macro-expr.rs
@@ -1,4 +1,4 @@
-#![feature(generators, generator_trait)]
+#![feature(coroutines, generator_trait)]
 #![deny(deprecated)]
 
 macro_rules! delay {

--- a/tests/ui/nightly/fail-yield-in-macro-stmt.rs
+++ b/tests/ui/nightly/fail-yield-in-macro-stmt.rs
@@ -1,4 +1,4 @@
-#![feature(generators, generator_trait)]
+#![feature(coroutines, generator_trait)]
 #![deny(deprecated)]
 
 macro_rules! delay {

--- a/tests/ui/nightly/pass-yield-empty.rs
+++ b/tests/ui/nightly/pass-yield-empty.rs
@@ -1,4 +1,4 @@
-#![feature(generators)]
+#![feature(coroutines)]
 
 use fauxgen::Generator;
 

--- a/tests/ui/nightly/pass-yield-nested-real-gen.rs
+++ b/tests/ui/nightly/pass-yield-nested-real-gen.rs
@@ -1,4 +1,4 @@
-#![feature(generators, generator_trait)]
+#![feature(coroutines, generator_trait)]
 
 #[fauxgen::generator]
 fn gen() {

--- a/tests/ui/nightly/pass-yield-syntax.rs
+++ b/tests/ui/nightly/pass-yield-syntax.rs
@@ -1,4 +1,4 @@
-#![feature(generators)]
+#![feature(coroutines)]
 
 #[fauxgen::generator(yield = i32)]
 fn gen() {

--- a/tests/ui/pass/all-params.rs
+++ b/tests/ui/pass/all-params.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 mod dummy {
     pub use fauxgen::*;
 

--- a/tests/ui/pass/elided-arg-lifetime.rs
+++ b/tests/ui/pass/elided-arg-lifetime.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 type Arg<'a> = &'a str;
 
 #[fauxgen::generator(arg = Arg<'_>)]

--- a/tests/ui/pass/elided-return-lifetime.rs
+++ b/tests/ui/pass/elided-return-lifetime.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 type Return<'a> = &'a str;
 
 #[fauxgen::generator]

--- a/tests/ui/pass/elided-yield-lifetime.rs
+++ b/tests/ui/pass/elided-yield-lifetime.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 type Yield<'a> = &'a str;
 
 #[fauxgen::generator(yield = Yield<'_>)]


### PR DESCRIPTION
This is safe because the generator only exposes `&mut` methods.