### PR TITLE
Fix build when `macros` feature is disabled

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,14 +1,18 @@
 use std::pin::Pin;
 
-use crate::{generator, Generator, GeneratorState};
+use crate::{Generator, GeneratorState};
 
+#[cfg(feature = "macros")]
+use crate::generator;
+
+#[cfg(feature = "macros")]
 used_in_docs!(generator);
 
 /// Wrapper around a generator that implements [`Iterator`].
 ///
 /// The generators created by the [`generator`] macro implement [`Iterator`]
 /// once they are pinned. For other implementations of [`Generator`], though,
-/// you can use `GeneratorIter` to convert them into an interator.
+/// you can use `GeneratorIter` to convert them into an iterator.
 pub struct GeneratorIter<G>(G);
 
 impl<G> GeneratorIter<G> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,8 +3,12 @@ use std::task::{Context, Poll};
 
 use futures_core::Stream;
 
-use crate::{generator, AsyncGenerator, GeneratorState};
+use crate::{AsyncGenerator, GeneratorState};
 
+#[cfg(feature = "macros")]
+use crate::generator;
+
+#[cfg(feature = "macros")]
 used_in_docs!(generator);
 
 /// Wrapper around an async generator that implements [`Stream`].


### PR DESCRIPTION
Before:

```
$ cargo check --no-default-features
   Compiling fauxgen v0.1.5 (/Users/romac/Code/vendors/fauxgen)
error[E0432]: unresolved import `crate::generator`
   --> src/iter.rs:3:13
    |
  3 | use crate::{generator, Generator, GeneratorState};
    |             ^^^^^^^^^
    |             |
    |             no `generator` in the root
    |             help: a similar name exists in the module: `Generator`
    |
note: found an item that was configured out
   --> src/lib.rs:241:25
    |
240 | #[cfg(feature = "macros")]
    |       ------------------ the item is gated behind the `macros` feature
241 | pub use fauxgen_macros::generator;
    |                         ^^^^^^^^^

error[E0432]: unresolved import `crate::generator`
   --> src/stream.rs:6:13
    |
  6 | use crate::{generator, AsyncGenerator, GeneratorState};
    |             ^^^^^^^^^
    |             |
    |             no `generator` in the root
    |             help: a similar name exists in the module: `Generator`
    |
note: found an item that was configured out
   --> src/lib.rs:241:25
    |
240 | #[cfg(feature = "macros")]
    |       ------------------ the item is gated behind the `macros` feature
241 | pub use fauxgen_macros::generator;
```

After:

```
$ cargo check --no-default-features
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
```