### PR TITLE
Rename lifetime from 'gen to 'gen_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Breaking change: the lifetime name associated with generators is now `gen_`,
+  as `gen` is a keyword in Rust 2024.
 
 ## [0.1.6]
 ### Changed

--- a/macros/src/generator.rs
+++ b/macros/src/generator.rs
@@ -226,13 +226,13 @@ impl VisitMut for ExpandYield<'_> {
 ///
 /// Output:
 /// ```ignore
-/// fn some_fn<'a, 'life2, 'gen>(self, x: &'a T, y: &'life2 u32) ->
-///     (Sync|Async)Generator<impl Future<Output = Ret> + 'gen, A, B>
+/// fn some_fn<'a, 'life2, 'gen_>(self, x: &'a T, y: &'life2 u32) ->
+///     (Sync|Async)Generator<impl Future<Output = Ret> + 'gen_, A, B>
 /// where
-///     'a: 'gen,
-///     'life2: 'gen,
-///     T: 'gen,
-///     Self: 'gen;
+///     'a: 'gen_,
+///     'life2: 'gen_,
+///     T: 'gen_,
+///     Self: 'gen_;
 /// ```
 fn transform_sig(
     sig: &mut syn::Signature,
@@ -244,7 +244,7 @@ fn transform_sig(
     use std::mem;
 
     let gen_lt: syn::Lifetime = syn::parse_quote_spanned! {
-        sig.ident.span() => 'gen
+        sig.ident.span() => 'gen_
     };
     let gen_lt = &gen_lt;
     let mut needs_gen = false;

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -9,7 +9,7 @@ async fn outer() {
 }
 
 #[generator(yield = u32)]
-async fn inner<F>(func: impl FnOnce() -> F + 'gen)
+async fn inner<F>(func: impl FnOnce() -> F + 'gen_)
 where
     F: Future<Output = ()>,
 {


### PR DESCRIPTION
gen has become a keyword in Rust 2024; code produced by fauxgen's macro  uses 'gen as a lifetime name, which leads to breakage in Rust 2024  use-sites. So, rename to something else - suffixing with an underscore  suffices and, while a little ugly, using these lifetimes is likely to be  the rare case anyway.

This is a breaking change (as shown by tests/nested.rs needing  adaptation).

Keeping the name as-is and instead using raw identifier syntax (new in  Rust 2021) was an option, but introduces complications of its own: one,  AIUI it would break usage in earlier editions and so still be a breaking  change; two, the tests break and I'm not sure why (trybuild not using  the right edition?); three, the syntax is ugly and uglier than a  trailing underscore - long-term, the latter's the way to go.

I wasn't able to work out how best to test this (specifically, how to  get trybuild to use a specific edition).